### PR TITLE
Fixes #38 [Users] nickname instead of nickName

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 |Date|Type|Description|Link|
 |---|---|---|---|
+|2016-09-05|UPDATE|Fixes a typo (issue #38)|[`/users/{userId}`](api/v3/users/user_id.md), <br />[`/users/me`](api/v3/users/me.md)|
 |2016-08-25|UPDATE|The parameter `inservice` was replaced by `in_service`|[`/ktype/{ktype}`](compat/v1/ktype/ktype.md)
 |2016-08-01|ADD|Add compatibility API|[`/compat/v1`](compat/v1/README.md)|
 |2016-07-27|UPDATE|Typo in stats|[`/cars/{carId}/stats/usedtime`](api/v3/cars/stats/usedtime.md)|

--- a/api/api/v3/users/me.md
+++ b/api/api/v3/users/me.md
@@ -32,7 +32,7 @@ There is *no parameter* for this API
     "id": 42,
     "lastName": "Doe",
     "firstName": "John",
-    "nickname": "Johny",
+    "nickName": "Johny",
     "gender": "MALE",
     "birthDate": "2016-01-11T00:00:00+00:00",
     "licenceDeliveryDate": "2014-08-13T00:00:00+00:00",

--- a/api/api/v3/users/user_id.md
+++ b/api/api/v3/users/user_id.md
@@ -43,7 +43,7 @@ The `env` variable as the host of the route can be changed for testing purpose.
     "id": 42,
     "lastName": "Doe",
     "firstName": "John",
-    "nickname": "Johny",
+    "nickName": "Johny",
     "gender": "MALE",
     "birthDate": "2016-01-11T00:00:00+00:00",
     "licenceDeliveryDate": "2014-08-13T00:00:00+00:00",


### PR DESCRIPTION
- Replace `nickname` by `nickName` in `users/{userId}` and `users/me`
- Update changelog