### PR TITLE
fix (doc): Typo in access_token

### DIFF
--- a/api/api/v3/auth/access_token.md
+++ b/api/api/v3/auth/access_token.md
@@ -105,7 +105,7 @@ For this request, you'll need *2 POST* parameters.
 |Parameter name|Parameter value|
 |---|---|
 |`grant_type`|`refresh_token`|
-|`refresh_token`|The *refresh_token* you saved from the first time you asked one|
+|`refresh_token`|The *refresh_token* you saved from the last time you asked one|
 
 And then `POST` it
 


### PR DESCRIPTION
In the `access_token` doc, there is a typo that can misguide the users.
You have to use the last refresh token and replace it each time.